### PR TITLE
[HOTFIX] I152 change django port to 8081 and fix .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ APP_NAME=Elucidate
 APP_ENV=DEVELOPMENT
 
 #==============================NUXT SETTINGS
-BACKEND_URL="http://localhost:8081/api/
+BACKEND_URL="http://localhost:8081/api/"
 
 #================================DATABASE
 POSTGRES_DB=postgres

--- a/server/api/settings.py
+++ b/server/api/settings.py
@@ -14,7 +14,7 @@ from django.core.management.commands.runserver import Command as runserver
 
 
 runserver.default_addr = "0"
-runserver.default_port = "8000"
+runserver.default_port = "8081"
 
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.


### PR DESCRIPTION
## Change Summary
**[Briefly summarise the changes that you made. Just high-level stuff]**
- Revert default Django port to 8081
- fix .env.example missing closing `"`
### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [ ] The pull request title has an issue number
- [ ] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
**[Is there anything in particular in the review that I should be aware of?]**

# Related issue

- Resolve #152